### PR TITLE
Add support for sprockets-rails 3.0+

### DIFF
--- a/lib/spritely.rb
+++ b/lib/spritely.rb
@@ -1,5 +1,6 @@
 require 'sass'
 require 'sprockets/rails/version'
+require 'sprockets/railtie'
 require 'sprockets/version'
 require 'spritely/sass_functions'
 require 'spritely/sprockets/manifest'
@@ -8,7 +9,11 @@ require 'spritely/adapters/sprockets_3'
 
 module Spritely
   def self.environment
-    ::Rails.application.assets
+    if sprockets_rails_version == 3
+      ::Rails.application.assets || ::Sprockets::Railtie.build_environment(::Rails.application)
+    else
+      ::Rails.application.assets
+    end
   end
 
   def self.directory
@@ -21,6 +26,10 @@ module Spritely
 
   def self.sprockets_version
     Gem::Version.new(Sprockets::VERSION).segments.first
+  end
+
+  def self.sprockets_rails_version
+    Gem::Version.new(Sprockets::Rails::VERSION).segments.first
   end
 
   def self.sprockets_adapter

--- a/spec/spritely_spec.rb
+++ b/spec/spritely_spec.rb
@@ -2,9 +2,25 @@ require 'spec_helper'
 
 describe Spritely do
   describe '.environment' do
-    before { stub_const('::Rails', double(application: double(assets: 'assets environment'))) }
+    let(:application) { double(assets: 'assets environment') }
+
+    before { stub_const('::Rails', double(application: application)) }
 
     its(:environment) { should eq('assets environment') }
+
+    context 'sprockets-rails version 3' do
+      before { stub_const('Sprockets::Rails::VERSION', '3.0.0') }
+
+      its(:environment) { should eq('assets environment') }
+
+      context 'the Rails application assets environment is nil' do
+        let(:application) { double(assets: nil) }
+
+        before { allow(::Sprockets::Railtie).to receive(:build_environment).with(application).and_return('new assets environment') }
+
+        its(:environment) { should eq('new assets environment') }
+      end
+    end
   end
 
   describe '.directory' do


### PR DESCRIPTION
In sprockets-rails 3.0, `Rails.application.assets` [is not set](https://github.com/rails/sprockets-rails/blob/v3.0.0/lib/sprockets/railtie.rb#L163-L168) if `Rails.application.config.assets.compile` is set to `false`.

We now do something very similar to what sprockets-rails does itself within the [Rake task definition](https://github.com/rails/sprockets-rails/blob/v3.0.0/lib/sprockets/rails/task.rb#L17-L25).