### PR TITLE
Require Ruby 2.0+

### DIFF
--- a/lib/spritely.rb
+++ b/lib/spritely.rb
@@ -25,11 +25,11 @@ module Spritely
   end
 
   def self.sprockets_version
-    Gem::Version.new(Sprockets::VERSION).segments.first
+    Gem::Version.new(::Sprockets::VERSION).segments.first
   end
 
   def self.sprockets_rails_version
-    Gem::Version.new(Sprockets::Rails::VERSION).segments.first
+    Gem::Version.new(::Sprockets::Rails::VERSION).segments.first
   end
 
   def self.sprockets_adapter

--- a/lib/spritely/sprockets/manifest.rb
+++ b/lib/spritely/sprockets/manifest.rb
@@ -1,17 +1,20 @@
 require 'sprockets/manifest'
-require 'active_support/core_ext/module/aliasing'
 
-module Sprockets
+module Spritely
   # In order to hook into Sprockets' asset compilation appropriately, we must
   # chain our own implementation of `compile`. Our extension calls up to the
   # original, and then performs the same action on the generated sprite images,
   # forcing the sprites to be part of the compiled asset manifest.
-  class Manifest
-    def compile_with_sprites(*args)
-      compile_without_sprites(*args)
-      compile_without_sprites(*Dir.glob(Spritely.directory.join('*.png')))
+  module Sprockets
+    module Manifest
+      def compile(*args)
+        super
+        super(*Dir.glob(Spritely.directory.join('*.png')))
+      end
     end
 
-    alias_method_chain :compile, :sprites
+    # TODO: Once we drop support for Ruby 2.0, stop using `send`.
+    # `Module#prepend` was made public in Ruby 2.1.
+    ::Sprockets::Manifest.send(:prepend, Manifest)
   end
 end

--- a/spritely.gemspec
+++ b/spritely.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"]
   s.test_files = Dir["spec/**/*"]
 
+  s.required_ruby_version = '>= 2.0.0'
+
   s.add_dependency 'chunky_png', '~> 1.3'
   s.add_dependency 'railties', '>= 4.1', '< 5.0'
   s.add_dependency 'sass', '~> 3.1'


### PR DESCRIPTION
Replaces our use of `alias_method_chain` with `Module#prepend`.