### PR TITLE
Get tests passing on Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,3 @@ matrix:
       gemfile: gemfiles/rails_5_0_sprockets_rails_2.gemfile
     - rvm: 2.1.8
       gemfile: gemfiles/rails_5_0.gemfile
-  allow_failures:
-    - gemfile: gemfiles/rails_5_0_sprockets_rails_2.gemfile
-    - gemfile: gemfiles/rails_5_0.gemfile

--- a/spec/fixtures/rails-app/config/initializers/assets.rb
+++ b/spec/fixtures/rails-app/config/initializers/assets.rb
@@ -1,3 +1,9 @@
 # Rails 4.2 turns on asset digest in development.
 # This turns them on for all Rails versions.
 Rails.application.config.assets.digest = true
+
+# Rails 5.0 doesn't currently depend on sass-rails.
+# Until it does, set the Sass style to `:nested` (the default) across all Rails versions.
+if Rails.application.config.respond_to?(:sass)
+  Rails.application.config.sass.style = :nested
+end

--- a/spec/integration/stylesheet_spec.rb
+++ b/spec/integration/stylesheet_spec.rb
@@ -10,8 +10,7 @@ describe 'Stylesheet generation', :integration do
     it { should include(<<-CSS.strip_heredoc
       body {
         background-image: url(#{background_image_url});
-        background-position: 0 0;
-      }
+        background-position: 0 0; }
     CSS
     ) }
   end
@@ -22,8 +21,7 @@ describe 'Stylesheet generation', :integration do
         background-image: url(#{background_image_url});
         background-position: -150px -806px;
         width: 200px;
-        height: 214px;
-      }
+        height: 214px; }
     CSS
     ) }
   end


### PR DESCRIPTION
The reason tests were failing are because Rails 5.0 doesn't currently depend on sass-rails, which is what sets the Sass style to `:expanded`.