### PR TITLE
Stop depending on railties, instead depend directly on activesupport

### DIFF
--- a/spec/integration/precompilation_spec.rb
+++ b/spec/integration/precompilation_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'active_support/core_ext/string'
 
 describe 'Precompilation', :integration do
   it 'should create the sprite in the right location' do

--- a/spritely.gemspec
+++ b/spritely.gemspec
@@ -18,12 +18,13 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
+  s.add_dependency 'activesupport', '>= 4.1'
   s.add_dependency 'chunky_png', '~> 1.3'
-  s.add_dependency 'railties', '>= 4.1'
   s.add_dependency 'sass', '~> 3.1'
   s.add_dependency 'sprockets-rails', '>= 2.0'
 
   s.add_development_dependency 'pry-byebug'
+  s.add_development_dependency 'railties'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 3.0'
   s.add_development_dependency 'rspec-its'


### PR DESCRIPTION
We don't actually require railties, just activesupport.