### PR TITLE
Provide a Sass mixin that includes all 4 necessary CSS properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,11 @@ Spritely takes advantage of Sprockets directives to define how a sprite should b
 
 ### Stylesheet
 
+If you aren't doing anything special, you can use a Spritely-provided Sass mixin:
+
 ```scss
 #icon {
-  background: {
-    image: spritely-url("application");
-    position: spritely-position("application", "icon");
-  }
-  width: spritely-width("application", "icon");
-  height: spritely-height("application", "icon");
+  @include spritely-image("application", "icon");
 }
 ```
 
@@ -48,6 +45,26 @@ The compiled CSS should look something like this:
   background-position: 0 25px;
   width: 20px;
   height: 20px;
+}
+```
+
+Otherwise, you can use the Spritely Sass functions directly:
+
+```scss
+#icon {
+  background: {
+    image: spritely-url("application");
+    position: spritely-position("application", "icon");
+  }
+}
+```
+
+The compiled CSS should look something like this:
+
+```css
+#icon {
+  background-image: url(/assets/sprites/application.png);
+  background-position: 0 25px;
 }
 ```
 

--- a/app/assets/stylesheets/_spritely.scss
+++ b/app/assets/stylesheets/_spritely.scss
@@ -1,0 +1,8 @@
+@mixin spritely-image($sprite_name, $image) {
+  background: {
+    image: spritely-url($sprite_name);
+    position: spritely-position($sprite_name, $image);
+  }
+  width: spritely-width($sprite_name, $image);
+  height: spritely-height($sprite_name, $image);
+}

--- a/lib/spritely.rb
+++ b/lib/spritely.rb
@@ -3,6 +3,10 @@ require 'spritely/sass_functions'
 require 'spritely/sprockets/preprocessor'
 require 'spritely/sprockets/transformer'
 
+if defined?(::Rails::Engine)
+  require 'spritely/engine'
+end
+
 module Spritely
 end
 

--- a/lib/spritely/engine.rb
+++ b/lib/spritely/engine.rb
@@ -1,0 +1,4 @@
+module Spritely
+  class Engine < ::Rails::Engine
+  end
+end


### PR DESCRIPTION
Instead of having to write this out each time:

```scss
background: {
  image: spritely-url("application");
  position: spritely-position("application", "icon");
}
width: spritely-width("application", "icon");
height: spritely-height("application", "icon");
```

You can now do this:

```scss
@include spritely-image("application", "icon");
```

Just `@import "spritely";` into your Sass files.

Closes #16.