### PR TITLE
Expose sprite map width and height

### DIFF
--- a/lib/spritely/sass_functions.rb
+++ b/lib/spritely/sass_functions.rb
@@ -27,16 +27,24 @@ module Spritely
 
     ::Sass::Script::Functions.declare :spritely_background, [:sprite_name, :image_name]
 
-    def spritely_width(sprite_name, image_name)
-      image = find_image(sprite_name, image_name)
+    def spritely_width(sprite_name, image_name = nil)
+      image = if image_name
+        find_image(sprite_name, image_name)
+      else
+        find_sprite_map(sprite_name)
+      end
 
       Sass::Script::Number.new(image.width, ['px'])
     end
 
     ::Sass::Script::Functions.declare :spritely_width, [:sprite_name, :image_name]
 
-    def spritely_height(sprite_name, image_name)
-      image = find_image(sprite_name, image_name)
+    def spritely_height(sprite_name, image_name = nil)
+      image = if image_name
+        find_image(sprite_name, image_name)
+      else
+        find_sprite_map(sprite_name)
+      end
 
       Sass::Script::Number.new(image.height, ['px'])
     end
@@ -46,15 +54,19 @@ module Spritely
     private
 
     def find_image(sprite_name, image_name)
+      sprite_map = find_sprite_map(sprite_name)
+
+      sprite_map.find(image_name.value) || raise(Sass::SyntaxError, "No image '#{image_name.value}' found in sprite map '#{sprite_map.name}'.")
+    end
+
+    def find_sprite_map(sprite_name)
       sprockets_context.link_asset("sprites/#{sprite_name.value}.png")
 
-      sprite_map = sprite_maps.fetch(sprite_name.value) do |name|
+      sprite_maps.fetch(sprite_name.value) do |name|
         asset = sprockets_environment.find_asset("sprites/#{name}.png.sprite") || raise(Sass::SyntaxError, "No sprite map '#{name}' found.")
 
         sprite_maps[name] = SpriteMap.new(name, sprockets_environment, asset.metadata[:sprite_directives])
       end
-
-      sprite_map.find(image_name.value) || raise(Sass::SyntaxError, "No image '#{image_name.value}' found in sprite map '#{sprite_map.name}'.")
     end
 
     def sprite_maps

--- a/spec/spritely/sass_functions_spec.rb
+++ b/spec/spritely/sass_functions_spec.rb
@@ -3,7 +3,7 @@ require 'sprockets'
 
 describe Spritely::SassFunctions do
   let(:asset) { double(metadata: { sprite_directives: 'directives' }) }
-  let(:sprite_map) { double(name: 'test') }
+  let(:sprite_map) { double(name: 'test', width: 100, height: 200) }
   let(:image) { double(left: 10, top: 12, width: 25, height: 50) }
 
   before do
@@ -12,7 +12,7 @@ describe Spritely::SassFunctions do
     allow(sprite_map).to receive(:find).with('bar').and_return(image)
   end
 
-  shared_examples "a sprite function that checks sprite map and image existence" do
+  shared_examples "a sprite function that checks sprite map existence" do
     context "the sprite map doesn't exist" do
       let(:asset) { nil }
 
@@ -20,6 +20,10 @@ describe Spritely::SassFunctions do
         expect { subject }.to raise_error(Sass::SyntaxError, "No sprite map 'test' found.")
       end
     end
+  end
+
+  shared_examples "a sprite function that checks sprite map and image existence" do
+    it_should_behave_like "a sprite function that checks sprite map existence"
 
     context "the image doesn't exist in the sprite map" do
       let(:image) { nil }
@@ -59,19 +63,39 @@ describe Spritely::SassFunctions do
   end
 
   describe '#spritely_width' do
-    subject { evaluate(".width { width: spritely-width('test', 'bar'); }") }
+    describe "image width" do
+      subject { evaluate(".width { width: spritely-width('test', 'bar'); }") }
 
-    it_should_behave_like "a sprite function that checks sprite map and image existence"
+      it_should_behave_like "a sprite function that checks sprite map and image existence"
 
-    it { should eq(".width {\n  width: 25px; }\n") }
+      it { should eq(".width {\n  width: 25px; }\n") }
+    end
+
+    describe "sprite width" do
+      subject { evaluate(".width { width: spritely-width('test'); }") }
+
+      it_should_behave_like "a sprite function that checks sprite map existence"
+
+      it { should eq(".width {\n  width: 100px; }\n") }
+    end
   end
 
   describe '#spritely_height' do
-    subject { evaluate(".height { height: spritely-height('test', 'bar'); }") }
+    describe "image width" do
+      subject { evaluate(".height { height: spritely-height('test', 'bar'); }") }
 
-    it_should_behave_like "a sprite function that checks sprite map and image existence"
+      it_should_behave_like "a sprite function that checks sprite map and image existence"
 
-    it { should eq(".height {\n  height: 50px; }\n") }
+      it { should eq(".height {\n  height: 50px; }\n") }
+    end
+
+    describe "sprite width" do
+      subject { evaluate(".height { height: spritely-height('test'); }") }
+
+      it_should_behave_like "a sprite function that checks sprite map existence"
+
+      it { should eq(".height {\n  height: 200px; }\n") }
+    end
   end
 
   def evaluate(value)


### PR DESCRIPTION
If a user doesn't provide an image name when using `spritely-height` and `spritely-width`, we now return the whole sprite maps' `height` and `width`, respectively.

For example, if a sprite map's outer width and height are `100px` and `200px`:

```scss
.test {
  width: spritely-width('test');
  height: spritely-height('test');
}
```

This CSS will be returned:

```css
.test {
  width: 100px;
  height: 200px;
}
```

Closes #20.