### PR TITLE
Support Sass 3.5+ (while dropping support for Sass < 3.3)

### DIFF
--- a/lib/spritely/sass_functions.rb
+++ b/lib/spritely/sass_functions.rb
@@ -16,13 +16,13 @@ module Spritely
       x = Sass::Script::Value::Number.new(-image.left, image.left == 0 ? [] : ['px'])
       y = Sass::Script::Value::Number.new(-image.top, image.top == 0 ? [] : ['px'])
 
-      Sass::Script::Value::List.new([x, y], :space)
+      sass_space_separated_list([x, y])
     end
 
     ::Sass::Script::Functions.declare :spritely_position, [:sprite_name, :image_name]
 
     def spritely_background(sprite_name, image_name)
-      Sass::Script::Value::List.new([spritely_url(sprite_name), spritely_position(sprite_name, image_name)], :space)
+      sass_space_separated_list([spritely_url(sprite_name), spritely_position(sprite_name, image_name)])
     end
 
     ::Sass::Script::Functions.declare :spritely_background, [:sprite_name, :image_name]
@@ -71,6 +71,17 @@ module Spritely
 
     def sprite_maps
       @sprite_maps ||= {}
+    end
+
+    def sass_space_separated_list(value)
+      # Sass 3.5 introduced support for bracketed lists (sass/sass@be02da0), which changed the
+      # method signature of `Sass::Script::Value::List#initialize` to accept the `separator` as a
+      # keyword argument rather than as the second positional argument.
+      if Gem::Version.new(Sass.version[:number]) < Gem::Version.new("3.5")
+        Sass::Script::Value::List.new(value, :space)
+      else
+        Sass::Script::Value::List.new(value, separator: :space)
+      end
     end
   end
 end

--- a/lib/spritely/sass_functions.rb
+++ b/lib/spritely/sass_functions.rb
@@ -5,7 +5,7 @@ module Spritely
     def spritely_url(sprite_name)
       sprockets_context.link_asset("sprites/#{sprite_name.value}.png")
 
-      asset_url(Sass::Script::String.new("sprites/#{sprite_name.value}.png"))
+      asset_url(Sass::Script::Value::String.new("sprites/#{sprite_name.value}.png"))
     end
 
     ::Sass::Script::Functions.declare :spritely_url, [:sprite_name]
@@ -13,16 +13,16 @@ module Spritely
     def spritely_position(sprite_name, image_name)
       image = find_image(sprite_name, image_name)
 
-      x = Sass::Script::Number.new(-image.left, image.left == 0 ? [] : ['px'])
-      y = Sass::Script::Number.new(-image.top, image.top == 0 ? [] : ['px'])
+      x = Sass::Script::Value::Number.new(-image.left, image.left == 0 ? [] : ['px'])
+      y = Sass::Script::Value::Number.new(-image.top, image.top == 0 ? [] : ['px'])
 
-      Sass::Script::List.new([x, y], :space)
+      Sass::Script::Value::List.new([x, y], :space)
     end
 
     ::Sass::Script::Functions.declare :spritely_position, [:sprite_name, :image_name]
 
     def spritely_background(sprite_name, image_name)
-      Sass::Script::List.new([spritely_url(sprite_name), spritely_position(sprite_name, image_name)], :space)
+      Sass::Script::Value::List.new([spritely_url(sprite_name), spritely_position(sprite_name, image_name)], :space)
     end
 
     ::Sass::Script::Functions.declare :spritely_background, [:sprite_name, :image_name]
@@ -34,7 +34,7 @@ module Spritely
         find_sprite_map(sprite_name)
       end
 
-      Sass::Script::Number.new(image.width, ['px'])
+      Sass::Script::Value::Number.new(image.width, ['px'])
     end
 
     ::Sass::Script::Functions.declare :spritely_width, [:sprite_name, :image_name]
@@ -46,7 +46,7 @@ module Spritely
         find_sprite_map(sprite_name)
       end
 
-      Sass::Script::Number.new(image.height, ['px'])
+      Sass::Script::Value::Number.new(image.height, ['px'])
     end
 
     ::Sass::Script::Functions.declare :spritely_height, [:sprite_name, :image_name]

--- a/spritely.gemspec
+++ b/spritely.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency 'chunky_png', '~> 1.3'
-  s.add_dependency 'sass', '~> 3.1'
+  s.add_dependency 'sass', '~> 3.3'
   s.add_dependency 'sprockets', '~> 3.0'
 
   s.add_development_dependency 'activesupport'


### PR DESCRIPTION
Sass 3.5 introduced support for bracketed lists (sass/sass@be02da0), which changed the method signature of [`Sass::Script::Value::List#initialize`](https://github.com/sass/sass/blob/3.5.0/lib/sass/script/value/list.rb#L22-L31) to accept the `separator` as a keyword argument rather than as the second positional argument.

This changes our implementation to support both the pre- and post-3.5 world.

While we're at it, it's time to drop support for Sass < 3.3:

* 3.1.x was last released on 2012-08-10 (3.1.21)
* 3.2.x was last released on 2014-04-05 (3.2.19)

3.3.x was also last released in 2014 (2014-08-01 as 3.3.14), but supporting the last 3 major versions (Sass only started following Semver from 3.5 onwards) seems like a reasonable amount.