### PR TITLE
Update tested Ruby versions, dropping support for < 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.5
-  - 2.3.1
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 gemfile:
   - gemfiles/rails_4_2_sprockets_rails_2.gemfile
   - gemfiles/rails_4_2.gemfile
@@ -14,12 +13,3 @@ gemfile:
 script: bundle exec rspec spec
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails_5_0_sprockets_rails_2.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails_5_0.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails_5_0_sprockets_rails_2.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails_5_0.gemfile

--- a/spritely.gemspec
+++ b/spritely.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"]
   s.test_files = Dir["spec/**/*"]
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.2.0'
 
   s.add_dependency 'chunky_png', '~> 1.3'
   s.add_dependency 'sass', '~> 3.3'


### PR DESCRIPTION
Ruby 2.0 went EOL on 2016-02-24 and Ruby 2.1 went EOL on 2017-04-01. Time to say goodbye!