### PR TITLE
Drop Ruby 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.10
   - 2.3.7
   - 2.4.4
   - 2.5.1

--- a/spritely.gemspec
+++ b/spritely.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"]
   s.test_files = Dir["spec/**/*"]
 
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.3.0'
 
   s.add_dependency 'chunky_png', '~> 1.3'
   s.add_dependency 'sass', '~> 3.3'


### PR DESCRIPTION
After the release of [Ruby 2.2.10](https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/), Ruby 2.2 has gone EOL.