### PR TITLE
Use underscores instead of dashes for multi-word directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ The default value is `left`.
 There are sometimes cases where you want to add some extra spacing (or padding) above or below images in your sprite. To do so for an image named `arrow.png`:
 
 ```
-//= spacing-above arrow 5
-//= spacing-below arrow 10
+//= spacing_above arrow 5
+//= spacing_below arrow 10
 ```
 
 This will add 5 pixels of spacing above `arrow.png` and 10 pixels of spacing below `arrow.png` within the sprite.
@@ -128,8 +128,8 @@ This will add 5 pixels of spacing above `arrow.png` and 10 pixels of spacing bel
 To do it for all images in a sprite map:
 
 ```
-//= spacing-above 5
-//= spacing-below 10
+//= spacing_above 5
+//= spacing_below 10
 ```
 
 ## Tests

--- a/lib/spritely/sprockets/preprocessor.rb
+++ b/lib/spritely/sprockets/preprocessor.rb
@@ -6,10 +6,10 @@ module Spritely
     #
     #   //= directory foo/bar
     #   //= repeat arrow true
-    #   //= spacing-below arrow 10
+    #   //= spacing_below arrow 10
     #   //= position another-image right
-    #   //= spacing-above 5
-    #   //= spacing-below 5
+    #   //= spacing_above 5
+    #   //= spacing_below 5
     #
     # To this:
     #
@@ -23,7 +23,7 @@ module Spritely
     #   }
     class Preprocessor < ::Sprockets::DirectiveProcessor
       CONFIG_DIRECTIVES = %w(directory).freeze
-      IMAGE_DIRECTIVES = %w(repeat position spacing-above spacing-below).freeze
+      IMAGE_DIRECTIVES = %w(repeat position spacing_above spacing_below).freeze
 
       def _call(input)
         @sprite_directives = { directory: nil, global: {}, images: {} }
@@ -52,20 +52,34 @@ module Spritely
       end
 
       def process_spacing_directive(*args)
-        Spritely.logger.warn "The `spacing` directive is deprecated and has been replaced by `spacing-below`. It will be removed in Spritely 3.0. (called from #{@filename})"
+        Spritely.logger.warn "The `spacing` directive is deprecated and has been replaced by `spacing_below`. It will be removed in Spritely 3.0. (called from #{@filename})"
 
-        public_send("process_spacing-below_directive", *args)
+        process_spacing_below_directive(*args)
+      end
+
+      # Use `define_method` here because of the dash in the directive name
+      define_method("process_spacing-above_directive") do |*args|
+        Spritely.logger.warn "The `spacing-above` directive is deprecated and has been replaced by `spacing_above`. It will be removed in Spritely 3.0. (called from #{@filename})"
+
+        process_spacing_above_directive(*args)
+      end
+
+      # Use `define_method` here because of the dash in the directive name
+      define_method("process_spacing-below_directive") do |*args|
+        Spritely.logger.warn "The `spacing-below` directive is deprecated and has been replaced by `spacing_below`. It will be removed in Spritely 3.0. (called from #{@filename})"
+
+        process_spacing_below_directive(*args)
       end
 
       private
 
       def process_image_option(directive, image, value)
         @sprite_directives[:images][image] ||= {}
-        @sprite_directives[:images][image][directive.tr('-', '_').to_sym] = value
+        @sprite_directives[:images][image][directive.to_sym] = value
       end
 
       def process_global_option(directive, value)
-        @sprite_directives[:global][directive.tr('-', '_').to_sym] = value
+        @sprite_directives[:global][directive.to_sym] = value
       end
 
       def merge_global_options!

--- a/spec/fixtures/rails-app/app/assets/images/sprites/application.png.sprite
+++ b/spec/fixtures/rails-app/app/assets/images/sprites/application.png.sprite
@@ -1,6 +1,6 @@
 //= repeat background true
-//= spacing-above football 10
-//= spacing-below football 100
-//= spacing-below mario 10
+//= spacing_above football 10
+//= spacing_below football 100
+//= spacing_below mario 10
 //= position mario right
-//= spacing-below 5
+//= spacing_below 5

--- a/spec/fixtures/rails-app/app/assets/images/sprites/foo.png.sprite
+++ b/spec/fixtures/rails-app/app/assets/images/sprites/foo.png.sprite
@@ -1,1 +1,1 @@
-//= spacing-below 5
+//= spacing_below 5

--- a/spec/spritely/sprockets/preprocessor_spec.rb
+++ b/spec/spritely/sprockets/preprocessor_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spritely::Sprockets::Preprocessor do
-  let(:data) { "//= spacing-below some-new-image 789\n//= position some-new-image right\n//= repeat another-image true\n//= repeat yet-another-image false\n//= spacing-below 901\n//= spacing-above 101\n//= position left" }
+  let(:data) { "//= spacing_below some-new-image 789\n//= position some-new-image right\n//= repeat another-image true\n//= repeat yet-another-image false\n//= spacing_below 901\n//= spacing_above 101\n//= position left" }
   let(:input) { {
     data: data,
     filename: "sprites/foo.png.sprite",
@@ -29,7 +29,39 @@ describe Spritely::Sprockets::Preprocessor do
       let(:data) { "//= spacing 5" }
 
       it 'warns the user' do
-        expect(Spritely.logger).to receive(:warn).with('The `spacing` directive is deprecated and has been replaced by `spacing-below`. It will be removed in Spritely 3.0. (called from sprites/foo.png.sprite)')
+        expect(Spritely.logger).to receive(:warn).with('The `spacing` directive is deprecated and has been replaced by `spacing_below`. It will be removed in Spritely 3.0. (called from sprites/foo.png.sprite)')
+
+        preprocessor._call(input)
+
+        expect(input[:metadata][:sprite_directives]).to eq(
+          directory: nil,
+          global: { spacing_below: '5' },
+          images: {}
+        )
+      end
+    end
+
+    describe 'spacing-above directive' do
+      let(:data) { "//= spacing-above 5" }
+
+      it 'warns the user' do
+        expect(Spritely.logger).to receive(:warn).with('The `spacing-above` directive is deprecated and has been replaced by `spacing_above`. It will be removed in Spritely 3.0. (called from sprites/foo.png.sprite)')
+
+        preprocessor._call(input)
+
+        expect(input[:metadata][:sprite_directives]).to eq(
+          directory: nil,
+          global: { spacing_above: '5' },
+          images: {}
+        )
+      end
+    end
+
+    describe 'spacing-below directive' do
+      let(:data) { "//= spacing-below 5" }
+
+      it 'warns the user' do
+        expect(Spritely.logger).to receive(:warn).with('The `spacing-below` directive is deprecated and has been replaced by `spacing_below`. It will be removed in Spritely 3.0. (called from sprites/foo.png.sprite)')
 
         preprocessor._call(input)
 


### PR DESCRIPTION
Sprockets uses underscores itself, so this lines up better with that convention. It also eliminates having dashes in method names, which while technically supported, really shouldn't be done.

This adds deprecations for the dasherized versions.