### PR TITLE
Drop Ruby 2.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.3.7
   - 2.4.4
   - 2.5.1
 gemfile:

--- a/spritely.gemspec
+++ b/spritely.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"]
   s.test_files = Dir["spec/**/*"]
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.4.0'
 
   s.add_dependency 'chunky_png', '~> 1.3'
   s.add_dependency 'sass', '~> 3.3'


### PR DESCRIPTION
Ruby 2.3 went [EOL back in March](https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/).