### PR TITLE
Replace most uses of `Struct` with conventional classes

### DIFF
--- a/lib/spritely/collection.rb
+++ b/lib/spritely/collection.rb
@@ -5,15 +5,24 @@ require 'spritely/layouts/vertical'
 module Spritely
   # A `SpriteMap` has a `Collection` that knows how to calculate the size of the
   # sprite, based on direction, image repetition, and spacing.
-  class Collection < Struct.new(:files, :sort_options, :layout_key, :options)
+  class Collection
     extend Forwardable
 
     def_delegators :layout, :width, :height, :position!
+
+    attr_reader :files, :sort_options, :layout_key, :options
 
     LAYOUTS = {
       horizontal: Layouts::Horizontal,
       vertical: Layouts::Vertical
     }.freeze
+
+    def initialize(files, sort_options, layout_key, options)
+      @files = files
+      @sort_options = sort_options
+      @layout_key = layout_key
+      @options = options
+    end
 
     def self.create(*args)
       new(*args).tap do |collection|

--- a/lib/spritely/generators/base.rb
+++ b/lib/spritely/generators/base.rb
@@ -1,6 +1,12 @@
 module Spritely
   module Generators
-    class Base < Struct.new(:sprite_map)
+    class Base
+      attr_reader :sprite_map
+
+      def initialize(sprite_map)
+        @sprite_map = sprite_map
+      end
+
       def build!
         raise NotImplementedError, "#{self.class} must implement #build!"
       end

--- a/lib/spritely/image.rb
+++ b/lib/spritely/image.rb
@@ -1,5 +1,5 @@
 module Spritely
-  class Image < Struct.new(:data)
+  Image = Struct.new(:data) do
     attr_accessor :top, :left
   end
 end

--- a/lib/spritely/layouts/base.rb
+++ b/lib/spritely/layouts/base.rb
@@ -1,6 +1,12 @@
 module Spritely
   module Layouts
-    class Base < Struct.new(:image_sets)
+    class Base
+      attr_reader :image_sets
+
+      def initialize(image_sets)
+        @image_sets = image_sets
+      end
+
       def position!
         raise NotImplementedError, "#{self.class} must implement #position!"
       end

--- a/lib/spritely/sprockets/transformer.rb
+++ b/lib/spritely/sprockets/transformer.rb
@@ -3,13 +3,19 @@ require 'spritely/sprite_map'
 
 module Spritely
   module Sprockets
-    class Transformer < Struct.new(:input)
+    class Transformer
+      attr_reader :input
+
       def self.call(input)
         new(input).call
       end
 
       def self.cache_key
         @cache_key ||= "#{name}:#{Spritely::VERSION}".freeze
+      end
+
+      def initialize(input)
+        @input = input
       end
 
       def call

--- a/spec/spritely/generators/chunky_png_spec.rb
+++ b/spec/spritely/generators/chunky_png_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'ostruct'
 
 describe Spritely::Generators::ChunkyPng do
   let(:png_canvas) { double(metadata: {}, to_blob: "final PNG content") }

--- a/spec/spritely/image_set_spec.rb
+++ b/spec/spritely/image_set_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'ostruct'
 
 describe Spritely::ImageSet do
   let(:path) { "#{__dir__}/../fixtures/test/foo.png" }


### PR DESCRIPTION
Basically none of these classes make sense conceptually as `Struct`s, we were just eliminating some boilerplate, which is an anti-pattern.

One of the still makes sense (`Image`), but we really shouldn't be inheriting from `Struct.new`, but assigning it to the `Image` constant.